### PR TITLE
Makefile: Integrate all functionality from exlaunch.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,41 @@
-ifndef LOAD_KIND
-$(error LOAD_KIND is not set! (are you not using exlaunch.sh?))
+# Define paths.
+PWD := $(shell pwd)
+MISC_PATH := $(PWD)/misc
+MK_PATH := $(MISC_PATH)/mk
+SCRIPTS_PATH := $(MISC_PATH)/scripts
+SPECS_PATH := $(MISC_PATH)/specs
+
+# Define common variables.
+NAME := $(shell basename $(PWD))
+OUT := $(PWD)/deploy
+SD_OUT := atmosphere/contents/$(PROGRAM_ID)/exefs
+
+# To configure exlaunch, edit config.mk.
+include $(PWD)/config.mk
+
+# Set load kind specific variables.
+ifeq ($(LOAD_KIND), Module)
+    LOAD_KIND_ENUM := 2
+    BINARY_NAME := subsdk9 # TODO: support subsdkX?
+    SPECS_NAME := module.specs
+    MK_NAME := module.mk
+else ifeq ($(LOAD_KIND), AsRtld)
+    LOAD_KIND_ENUM := 1
+    BINARY_NAME := rtld
+    SPECS_NAME := as_rtld.specs
+    MK_NAME := as_rtld.mk
+else
+    $(error LOAD_KIND is invalid, please check config.mk)
 endif
 
 .PHONY: clean all
 
 # Built internal C flags variable.
-export EXL_CFLAGS	:= $(C_FLAGS) -DEXL_LOAD_KIND=$(LOAD_KIND) -DEXL_LOAD_KIND_ENUM=$(LOAD_KIND_ENUM) -DEXL_PROGRAM_ID=0x$(PROGRAM_ID)
-export EXL_CXXFLAGS	:= $(CXX_FLAGS)
+EXL_CFLAGS   := $(C_FLAGS) -DEXL_LOAD_KIND=$(LOAD_KIND) -DEXL_LOAD_KIND_ENUM=$(LOAD_KIND_ENUM) -DEXL_PROGRAM_ID=0x$(PROGRAM_ID)
+EXL_CXXFLAGS := $(CXX_FLAGS)
+
+# Export all of our variables to sub-makes and sub-processes.
+export
 
 include $(MK_PATH)/$(MK_NAME)
 include $(MK_PATH)/common.mk

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,4 @@ export
 
 include $(MK_PATH)/$(MK_NAME)
 include $(MK_PATH)/common.mk
+include $(MK_PATH)/deploy.mk

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ MISC_PATH := $(PWD)/misc
 MK_PATH := $(MISC_PATH)/mk
 SCRIPTS_PATH := $(MISC_PATH)/scripts
 SPECS_PATH := $(MISC_PATH)/specs
+NPDM_JSON_PATH := $(MISC_PATH)/npdm-json
 
 # Define common variables.
 NAME := $(shell basename $(PWD))
@@ -40,3 +41,4 @@ export
 include $(MK_PATH)/$(MK_NAME)
 include $(MK_PATH)/common.mk
 include $(MK_PATH)/deploy.mk
+include $(MK_PATH)/npdm.mk

--- a/config.mk
+++ b/config.mk
@@ -12,6 +12,27 @@ PROGRAM_ID := 0100801011c3e000
 # Optional path to copy the final ELF to, for convenience.
 ELF_EXTRACT :=
 
+# Python command to use. Must be Python 3.4+.
+PYTHON := python3
+
 # Additional C/C++ flags to use.
 C_FLAGS := 
 CXX_FLAGS := 
+
+# AsRtld settings
+#------------------------
+
+# Path to the SD card. Used to mount and deploy files on SD, likely with hekate UMS.
+MOUNT_PATH := /mnt/k
+
+# Module settings
+#------------------------
+
+# Settings for deploying over FTP. Used by the deploy-ftp.py script.
+FTP_IP := 192.168.0.235
+FTP_PORT := 5000
+FTP_USERNAME := anonymous
+FTP_PASSWORD :=
+
+# Settings for deploying to Ryu. Used by the deploy-ryu.sh script.
+RYU_PATH := /mnt/c/Users/shado/AppData/Roaming/Ryujinx

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,17 @@
+#----------------------------- User configuration -----------------------------
+
+# Common settings
+#------------------------
+
+# How you're loading your module. Used to determine how to find the target module. (AsRtld/Module/Kip)
+LOAD_KIND := Module
+
+# Program you're targetting. Used to determine where to deploy your files.
+PROGRAM_ID := 0100801011c3e000
+
+# Optional path to copy the final ELF to, for convenience.
+ELF_EXTRACT :=
+
+# Additional C/C++ flags to use.
+C_FLAGS := 
+CXX_FLAGS := 

--- a/config.mk
+++ b/config.mk
@@ -15,6 +15,9 @@ ELF_EXTRACT :=
 # Python command to use. Must be Python 3.4+.
 PYTHON := python3
 
+# JSON to use to make .npdm
+NPDM_JSON := qlaunch.json
+
 # Additional C/C++ flags to use.
 C_FLAGS := 
 CXX_FLAGS := 

--- a/exlaunch.sh
+++ b/exlaunch.sh
@@ -1,84 +1,26 @@
 #!/bin/bash
-#----------------------------- User configuration -----------------------------
 
-# Common settings
-#------------------------
+# User configuration has moved to misc/mk/config.mk.
 
-# How you're loading your module. Used to determine how to find the target module. (AsRtld/Module/Kip)
-export LOAD_KIND="Module"
-# Program you're targetting. Used to determine where to deploy your files.
-export PROGRAM_ID="0100801011c3e000"
-# Optional path to copy the final ELF to, for convenience.
-export ELF_EXTRACT=""
-# Python command to use. Must be Python 3.4+.
-export PYTHON="python3"
 # Make arguments.
-export MAKE_ARGS="-j8 V=1"
-# JSON to use to make .npdm
-export NPDM_JSON="qlaunch.json"
-# Additional C/C++ flags to use.
-export C_FLAGS=""
-export CXX_FLAGS=""
+MAKE_ARGS="-j8 V=1"
 
-# AsRtld settings
-#------------------------
-
-# Path to the SD card. Used to mount and deploy files on SD, likely with hekate UMS.
-export MOUNT_PATH="/mnt/k"
-
-# Module settings
-#------------------------
-
-# Settings for deploying over FTP. Used by the deploy-ftp.py script.
-export FTP_IP="192.168.0.235"
-export FTP_PORT="5000"
-export FTP_USERNAME="anonymous"
-export FTP_PASSWORD=""
-
-# Settings for deploying to Ryu. Used by the deploy-ryu.sh script.
-export RYU_PATH="/mnt/c/Users/shado/AppData/Roaming/Ryujinx"
-
-#-------------------------- End of user configuration --------------------------
-
-# Setup common variables.
-export MISC_PATH=$(pwd)/misc
-export MK_PATH=$MISC_PATH/mk
-export SCRIPTS_PATH=$MISC_PATH/scripts
-export SPECS_PATH=$MISC_PATH/specs
-export NPDM_JSON_PATH=$MISC_PATH/npdm-json
-
-# Setup variable for .json
-export NPDM_JSON=$NPDM_JSON_PATH/$NPDM_JSON
-
-# Import target env variables.
-source $SCRIPTS_PATH/target-common.sh
-
-# Import target env for load kind.
-if [ $LOAD_KIND == "Module" ]; then
-    export LOAD_KIND_ENUM=2
-    source $SCRIPTS_PATH/target-module.sh
-elif [ $LOAD_KIND == "AsRtld" ]; then
-    export LOAD_KIND_ENUM=1
-    source $SCRIPTS_PATH/target-rtld.sh
-else 
-    echo "Invalid LOAD_KIND!"
+# Determine the make verb from the user action.
+if [ "$1" == "build" ]; then
+    MAKE_VERB=""
+elif [ "$1" == "clean" ]; then
+    MAKE_VERB="clean"
+elif [ "$1" == "deploy-sd" ]; then
+    MAKE_VERB="deploy-sd"
+elif [ "$1" == "deploy-ftp" ]; then
+    MAKE_VERB="deploy-ftp"
+elif [ "$1" == "deploy-ryu" ]; then
+    MAKE_VERB="deploy-ryu"
+elif [ "$1" == "make-npdm-json" ]; then
+    MAKE_VERB="npdm-json"
+else
+    echo "Invalid arg. (build/clean/deploy-sd/deploy-ftp/deploy-ryu)"
     exit 1
 fi
 
-# Perform user action.
-if [ "$1" == "build" ]; then
-    make $MAKE_ARGS
-    source $SCRIPTS_PATH/post-build.sh
-elif [ "$1" == "clean" ]; then
-    make $MAKE_ARGS clean
-elif [ "$1" == "deploy-sd" ]; then
-    source $SCRIPTS_PATH/deploy-sd.sh
-elif [ "$1" == "deploy-ftp" ]; then
-    $PYTHON $SCRIPTS_PATH/deploy-ftp.py
-elif [ "$1" == "deploy-ryu" ]; then
-     source $SCRIPTS_PATH/deploy-ryu.sh
-elif [ "$1" == "make-npdm-json" ]; then
-    $PYTHON $SCRIPTS_PATH/make-npdm-json.py
-else
-    echo "Invalid arg. (build/clean/deploy-sd/deploy-ftp/deploy-ryu)"
-fi
+make $MAKE_ARGS $MAKE_VERB

--- a/misc/mk/common.mk
+++ b/misc/mk/common.mk
@@ -125,6 +125,7 @@ all: $(BUILD)
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(MK_PATH)/common.mk
+	@$(SHELL) $(SCRIPTS_PATH)/post-build.sh
 
 #---------------------------------------------------------------------------------
 clean:

--- a/misc/mk/deploy.mk
+++ b/misc/mk/deploy.mk
@@ -1,0 +1,10 @@
+.PHONY: deploy-sd deploy-ftp deploy-ryu
+
+deploy-sd:
+	@$(SHELL) $(SCRIPTS_PATH)/deploy-sd.sh
+
+deploy-ftp:
+	@$(PYTHON) $(SCRIPTS_PATH)/deploy-ftp.py
+
+deploy-ryu:
+	@$(SHELL) $(SCRIPTS_PATH)/deploy-ryu.sh

--- a/misc/mk/npdm.mk
+++ b/misc/mk/npdm.mk
@@ -1,6 +1,6 @@
 NPDM_JSON := $(NPDM_JSON_PATH)/$(NPDM_JSON)
 
-.PHONY: make-npdm-json
+.PHONY: npdm-json
 
 npdm-json:
 	@$(PYTHON) $(SCRIPTS_PATH)/make-npdm-json.py

--- a/misc/mk/npdm.mk
+++ b/misc/mk/npdm.mk
@@ -1,0 +1,6 @@
+NPDM_JSON := $(NPDM_JSON_PATH)/$(NPDM_JSON)
+
+.PHONY: make-npdm-json
+
+npdm-json:
+	@$(PYTHON) $(SCRIPTS_PATH)/make-npdm-json.py

--- a/misc/scripts/target-common.sh
+++ b/misc/scripts/target-common.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export NAME=$(basename $(pwd))
-export OUT=./deploy
-export SD_OUT=/atmosphere/contents/${PROGRAM_ID}/exefs

--- a/misc/scripts/target-module.sh
+++ b/misc/scripts/target-module.sh
@@ -1,4 +1,0 @@
-# TODO: support subsdkX?
-export BINARY_NAME=subsdk9
-export SPECS_NAME=module.specs
-export MK_NAME=module.mk

--- a/misc/scripts/target-rtld.sh
+++ b/misc/scripts/target-rtld.sh
@@ -1,3 +1,0 @@
-export BINARY_NAME=rtld
-export SPECS_NAME=as_rtld.specs
-export MK_NAME=as_rtld.mk


### PR DESCRIPTION
This allows easier integration with IDEs such as CLion. 

* User configuration has been moved to `misc/mk/config.mk`.
* `exlaunch.sh` still works as before, but it now just acts as a forwarder to `make`.
* I left the `make-npdm-json` stuff, though it doesn't appear to actually do anything.