### PR TITLE
Change PWD to support spaces in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define paths.
-PWD := $(shell pwd)
+PWD := $(shell echo "$(shell pwd)" | sed 's: :\\ :g')
 MISC_PATH := $(PWD)/misc
 MK_PATH := $(MISC_PATH)/mk
 SCRIPTS_PATH := $(MISC_PATH)/scripts


### PR DESCRIPTION
Updated the PWD definition to allow for spaces in the pwd by escaping them.

Windows paths, even over WSL (/mnt/driveletter) can often have spaces in the path that are not trivially renameable, like my own `/mnt/c/Users/Rose Hall/`. This PR aims to support these paths. It should be noted that by accepting this PR responsibility for handling paths with spaces is taken on by this repository. While such a responsibility should be the responsibility of tools like these (in my opinion) that may not be the opinion of maintainers 