### PR TITLE
Derive EXL_MODULE_NAME_LEN from EXL_MODULE_NAME automatically

### DIFF
--- a/source/lib/module.cpp
+++ b/source/lib/module.cpp
@@ -1,12 +1,15 @@
 #include "common.hpp"
 
 #include "program/setting.hpp"
+#include <string>
+
+constexpr const int ModuleNameLength = std::char_traits<char>::length(EXL_MODULE_NAME);
 
 struct ModuleName {
     int unknown;
     int name_length;
-    char name[EXL_MODULE_NAME_LEN + 1];
+    char name[ModuleNameLength + 1];
 };
 
 __attribute__((section(".nx-module-name")))
-const ModuleName s_ModuleName = {.unknown = 0, .name_length = EXL_MODULE_NAME_LEN, .name = EXL_MODULE_NAME};
+const ModuleName s_ModuleName = {.unknown = 0, .name_length = ModuleNameLength, .name = EXL_MODULE_NAME};

--- a/source/program/setting.hpp
+++ b/source/program/setting.hpp
@@ -3,7 +3,6 @@
 #include "common.hpp"
 
 #define EXL_MODULE_NAME "exlaunch"
-#define EXL_MODULE_NAME_LEN 8
 
 #define EXL_DEBUG
 #define EXL_USE_FAKEHEAP


### PR DESCRIPTION
Makes it so module.cpp doesn't need EXL_MODULE_NAME_LEN to get the length of the module name anymore.