### PR TITLE
change setting.hpp to use defines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,32 @@ else
     $(error LOAD_KIND is invalid, please check config.mk)
 endif
 
+ifeq ($(FAKEHEAP_SIZE),)
+    DEXL_FAKEHEAP := -DEXL_FAKEHEAP_SIZE=0x1000
+else
+    DEXL_FAKEHEAP := -DEXL_FAKEHEAP_SIZE=$(FAKEHEAP_SIZE) -DEXL_USE_FAKEHEAP
+endif
+
 .PHONY: clean all
 
 # Built internal C flags variable.
-EXL_CFLAGS   := $(C_FLAGS) -DEXL_LOAD_KIND=$(LOAD_KIND) -DEXL_LOAD_KIND_ENUM=$(LOAD_KIND_ENUM) -DEXL_PROGRAM_ID=0x$(PROGRAM_ID)
+EXL_CFLAGS   := $(C_FLAGS) \
+                $(DEXL_FAKEHEAP) \
+                -DEXL_LOAD_KIND=$(LOAD_KIND) \
+                -DEXL_LOAD_KIND_ENUM=$(LOAD_KIND_ENUM) \
+                -DEXL_PROGRAM_ID=0x$(PROGRAM_ID) \
+                -DEXL_MODULE_NAME=\"$(MODULE_NAME)\" \
+                -DEXL_JIT_SIZE=$(JIT_SIZE) \
+                -DEXL_INLINE_POOL_SIZE=$(INLINE_POOL_SIZE) \
+
+ifeq ($(DEBUG), 1)
+    EXL_CFLAGS := $(EXL_CFLAGS) -DEXL_DEBUG
+endif
+
+ifeq ($(SUPPORTS_REBOOTPAYLOAD), 1)
+    EXL_CFLAGS := $(EXL_CFLAGS) -DEXL_SUPPORTS_REBOOTPAYLOAD
+endif
+
 EXL_CXXFLAGS := $(CXX_FLAGS)
 
 # Export all of our variables to sub-makes and sub-processes.

--- a/config.mk
+++ b/config.mk
@@ -9,6 +9,25 @@ LOAD_KIND := Module
 # Program you're targetting. Used to determine where to deploy your files.
 PROGRAM_ID := 0100801011c3e000
 
+# Name of the module
+MODULE_NAME := exlaunch
+
+# Size of the fake .bss heap.
+# Set to empty to disable fake heap
+FAKEHEAP_SIZE := 0x5000
+
+# JIT area for hooks
+JIT_SIZE := 0x1000
+
+# Inline pool size
+INLINE_POOL_SIZE := 0x1000
+
+# Enable debug (1=enable, other=disable)
+DEBUG := 1
+
+# Should support rebooting to payload on abort (1=enable, other=disable)
+SUPPORTS_REBOOTPAYLOAD :=
+
 # Optional path to copy the final ELF to, for convenience.
 ELF_EXTRACT :=
 

--- a/misc/mk/common.mk
+++ b/misc/mk/common.mk
@@ -149,7 +149,7 @@ $(OUTPUT).nso	:	$(OUTPUT).elf $(OUTPUT).npdm
 
 $(OUTPUT).elf	:	$(OFILES)
 
-$(OFILES_SRC)	: $(HFILES_BIN)
+$(OFILES_SRC)	: $(HFILES_BIN) $(PWD)/config.mk
 
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data

--- a/source/lib/module.cpp
+++ b/source/lib/module.cpp
@@ -1,12 +1,15 @@
 #include "common.hpp"
 
+#include <string>
 #include "program/setting.hpp"
+
+constexpr const int ModuleNameLength = std::char_traits<char>::length(EXL_MODULE_NAME);
 
 struct ModuleName {
     int unknown;
     int name_length;
-    char name[EXL_MODULE_NAME_LEN + 1];
+    char name[ModuleNameLength + 1];
 };
 
 __attribute__((section(".nx-module-name")))
-const ModuleName s_ModuleName = {.unknown = 0, .name_length = EXL_MODULE_NAME_LEN, .name = EXL_MODULE_NAME};
+const ModuleName s_ModuleName = {.unknown = 0, .name_length = ModuleNameLength, .name = EXL_MODULE_NAME};

--- a/source/program/setting.hpp
+++ b/source/program/setting.hpp
@@ -2,25 +2,15 @@
 
 #include "common.hpp"
 
-#define EXL_MODULE_NAME "exlaunch"
-#define EXL_MODULE_NAME_LEN 8
-
-#define EXL_DEBUG
-#define EXL_USE_FAKEHEAP
-
-/*
-#define EXL_SUPPORTS_REBOOTPAYLOAD
-*/
-
 namespace exl::setting {
     /* How large the fake .bss heap will be. */
-    constexpr size_t HeapSize = 0x5000;
+    constexpr size_t HeapSize = EXL_FAKEHEAP_SIZE;
 
     /* How large the JIT area will be for hooks. */
-    constexpr size_t JitSize = 0x1000;
+    constexpr size_t JitSize = EXL_JIT_SIZE;
 
     /* How large the area will be inline hook pool. */
-    constexpr size_t InlinePoolSize = 0x1000;
+    constexpr size_t InlinePoolSize = EXL_INLINE_POOL_SIZE;
 
     /* Sanity checks. */
     static_assert(ALIGN_UP(JitSize, PAGE_SIZE) == JitSize, "");


### PR DESCRIPTION
Let settings to be passed in from defines, which can be configured in config.mk

Useful if other projects want to use exlaunch but doesn't want to change the source directly

Also incorporated #13 