### PR TITLE
chore: change naming style for out args

### DIFF
--- a/source/nn/fs/fs_directories.hpp
+++ b/source/nn/fs/fs_directories.hpp
@@ -5,11 +5,11 @@
 namespace nn::fs {
     /*
         Open a directory given the path and open mode.
-        handleOut: Pointer to write the handle into.
+        outHandle: Pointer to write the handle into.
         path: Path to the directory to open.
         openMode: Mode to open the directory with, see nn::fs::OpenDirectoryMode.
     */
-    Result OpenDirectory(DirectoryHandle* handleOut, char const* path, s32 openMode);
+    Result OpenDirectory(DirectoryHandle* outHandle, char const* path, s32 openMode);
 
     /*
         Closes directory.
@@ -19,12 +19,12 @@ namespace nn::fs {
 
     /* 
         Read entries for a given opened directory into a provided buffer.
-        entryCountOut: Pointer to write actual amount of entries read.
-        entriesOut: Pointer to buffer containing (entryBufferLength) amount of DirectoryEntry
+        outEntryCount: Pointer to write actual amount of entries read.
+        outEntries: Pointer to buffer containing (entryBufferLength) amount of DirectoryEntry
         handle: Handle of directory to be opened.
-        entryBufferLength: How many entries provided in the entriesOut argument.
+        entryBufferLength: How many entries provided in the outEntries argument.
     */
-    Result ReadDirectory(s64* entryCountOut, DirectoryEntry* entriesOut, DirectoryHandle handle, s64 entryBufferLength);
+    Result ReadDirectory(s64* outEntryCount, DirectoryEntry* outEntries, DirectoryHandle handle, s64 entryBufferLength);
 
     /* 
         Creates a directory at  given path.
@@ -34,10 +34,10 @@ namespace nn::fs {
 
     /*
         Get the amount of entries in a given opened directory.
-        entryCountOut: Pointer to write the entry count.
+        outEntryCount: Pointer to write the entry count.
         handle: Handle of the directory to count entries.
     */
-    Result GetDirectoryEntryCount(s64* entryCountOut, DirectoryHandle handle);
+    Result GetDirectoryEntryCount(s64* outEntryCount, DirectoryHandle handle);
 
     /*
         Delete a given directory path and all of it's subdirectories/folders.

--- a/source/nn/fs/fs_files.hpp
+++ b/source/nn/fs/fs_files.hpp
@@ -13,11 +13,11 @@ namespace nn::fs {
 
     /*
         Open a file.
-        handleOut:   Output for handle representing opened file.
+        outHandle:   Output for handle representing opened file.
         path:        File path to open.
         mode:        Mode to open file. See OpenMode.
     */
-    Result OpenFile(FileHandle* handleOut, char const* path, int mode);
+    Result OpenFile(FileHandle* outHandle, char const* path, int mode);
 
     /*
         Close a file.


### PR DESCRIPTION
less easy to miss when reading