### PR TITLE
feat: add opt-in float register access for inline hooks

### DIFF
--- a/source/lib/hook/base.hpp
+++ b/source/lib/hook/base.hpp
@@ -59,8 +59,14 @@ namespace exl::hook {
 
     using InlineCtx = arch::InlineCtx;
     using InlineCallback = util::CFuncPtr<void, InlineCtx*>;
+    using InlineFloatCtx = arch::InlineFloatCtx;
+    using InlineFloatCallback = void (*)(InlineFloatCtx*);
 
     inline void HookInline(uintptr_t hook, InlineCallback callback) {
-        arch::HookInline(hook, reinterpret_cast<uintptr_t>(callback));
+        arch::HookInline(hook, reinterpret_cast<uintptr_t>(callback), false);
+    }
+
+    inline void HookInline(uintptr_t hook, InlineFloatCallback callback) {
+        arch::HookInline(hook, reinterpret_cast<uintptr_t>(callback), true);
     }
 }

--- a/source/lib/hook/nx64/impl.hpp
+++ b/source/lib/hook/nx64/impl.hpp
@@ -8,5 +8,5 @@ namespace exl::hook::nx64 {
     void Initialize();
 
     uintptr_t Hook(uintptr_t hook, uintptr_t callback, bool do_trampoline = false);
-    void HookInline(uintptr_t hook, uintptr_t callback);
+    void HookInline(uintptr_t hook, uintptr_t callback, bool capture_floats);
 }

--- a/source/lib/hook/nx64/inline_asm.s
+++ b/source/lib/hook/nx64/inline_asm.s
@@ -12,11 +12,12 @@
 .endm
 
 /* Size of stack to reserve for the context. Adjust this along with CtxStackSize in inline_impl.cpp */
-.set CTX_STACK_SIZE, 0x100
+.set CTX_STACK_BASE_SIZE, 0x100
+.set CTX_STACK_FLOAT_SIZE, 0x200
 
 /* For these macros, LR is deliberately not backed up as that's handled by the entry's entrypoint. */
 .macro armBackupRegisters
-    sub sp, sp, CTX_STACK_SIZE
+    sub sp, sp, CTX_STACK_BASE_SIZE
     stp x0, x1, [sp, #0x00]
     stp x2, x3, [sp, #0x10]
     stp x4, x5, [sp, #0x20]
@@ -32,6 +33,26 @@
     stp x24, x25, [sp, #0xC0]
     stp x26, x27, [sp, #0xD0]
     stp x28, x29, [sp, #0xE0]
+.endm
+
+.macro armBackupFloatRegisters
+    sub sp, sp, CTX_STACK_FLOAT_SIZE
+    stp q0, q1, [sp, #0x00]
+    stp q2, q3, [sp, #0x20]
+    stp q4, q5, [sp, #0x40]
+    stp q6, q7, [sp, #0x60]
+    stp q8, q9, [sp, #0x80]
+    stp q10, q11, [sp, #0xA0]
+    stp q12, q13, [sp, #0xC0]
+    stp q14, q15, [sp, #0xE0]
+    stp q16, q17, [sp, #0x100]
+    stp q18, q19, [sp, #0x120]
+    stp q20, q21, [sp, #0x140]
+    stp q22, q23, [sp, #0x160]
+    stp q24, q25, [sp, #0x180]
+    stp q26, q27, [sp, #0x1A0]
+    stp q28, q29, [sp, #0x1C0]
+    stp q30, q31, [sp, #0x1E0]
 .endm
 
 .macro armRecoverRegisters
@@ -50,7 +71,27 @@
     ldp x24, x25, [sp, #0xC0]
     ldp x26, x27, [sp, #0xD0]
     ldp x28, x29, [sp, #0xE0]
-    add sp, sp, CTX_STACK_SIZE
+    add sp, sp, CTX_STACK_BASE_SIZE
+.endm
+
+.macro armRecoverFloatRegisters
+    ldp q0, q1, [sp, #0x00]
+    ldp q2, q3, [sp, #0x20]
+    ldp q4, q5, [sp, #0x40]
+    ldp q6, q7, [sp, #0x60]
+    ldp q8, q9, [sp, #0x80]
+    ldp q10, q11, [sp, #0xA0]
+    ldp q12, q13, [sp, #0xC0]
+    ldp q14, q15, [sp, #0xE0]
+    ldp q16, q17, [sp, #0x100]
+    ldp q18, q19, [sp, #0x120]
+    ldp q20, q21, [sp, #0x140]
+    ldp q22, q23, [sp, #0x160]
+    ldp q24, q25, [sp, #0x180]
+    ldp q26, q27, [sp, #0x1A0]
+    ldp q28, q29, [sp, #0x1C0]
+    ldp q30, q31, [sp, #0x1E0]
+    add sp, sp, CTX_STACK_FLOAT_SIZE
 .endm
 
 CODE_BEGIN exl_inline_hook_impl
@@ -68,6 +109,29 @@ CODE_BEGIN exl_inline_hook_impl
     /* Keep a hold of entry pointer before restoring all the registers. */
     mov lr, x19
 
+    armRecoverRegisters
+
+    /* Return to entry. */
+    ret
+CODE_END
+
+CODE_BEGIN exl_inline_float_hook_impl
+    armBackupRegisters
+    armBackupFloatRegisters
+
+    /* LR contains a pointer to the called entry here. */
+    mov x19, lr
+
+    /* Load inline context for the first argument of the callback. */
+    mov x0, sp
+    /* Load then call callback. */
+    ldr x20, [x19, #0x8]
+    blr x20
+
+    /* Keep a hold of entry pointer before restoring all the registers. */
+    mov lr, x19
+
+    armRecoverFloatRegisters
     armRecoverRegisters
 
     /* Return to entry. */

--- a/source/types.h
+++ b/source/types.h
@@ -34,6 +34,8 @@ typedef	unsigned short	ushort;
 typedef	unsigned int	uint;	
 typedef	unsigned long	ulong;
 
+typedef float f32;
+typedef double f64;
 
 #define ALIGN_UP(x, a) ((((uintptr_t)x) + (((uintptr_t)a)-1)) & ~(((uintptr_t)a)-1))
 #define ALIGN_DOWN(x, a) ((uintptr_t)(x) & ~(((uintptr_t)(a)) - 1))


### PR DESCRIPTION
Usage:
```c++
HOOK_DEFINE_INLINE(FloatHook) {
    static void Callback(exl::hook::InlineFloatCtx* ctx) {
        ctx->S[1] = ctx->S[0];
    }
};

HOOK_DEFINE_INLINE(NoFloatHook) {
    static void Callback(exl::hook::InlineCtx* ctx) {
        ctx->X[1] = ctx->X[0];
    }
};
```
Supports V, D and S, with V being a custom struct containing D1, D2 or S1, S2, S3, S4