### PR TITLE
fix compilation error caused by substitution failure when installing hook at raw pointer, implement `InstallAtSymbol` when exlaunch is loaded as a module

### DIFF
--- a/source/lib/hook/inline.hpp
+++ b/source/lib/hook/inline.hpp
@@ -3,6 +3,10 @@
 #include <common.hpp>
 
 #include "base.hpp"
+#ifdef EXL_LOAD_KIND_MODULE
+#include "ro.h"
+#endif
+
 
 #define HOOK_DEFINE_INLINE(name)                        \
 struct name : public ::exl::hook::impl::InlineHook<name>
@@ -27,5 +31,15 @@ namespace exl::hook::impl {
             hook::HookInline(ptr, Derived::Callback);
         }
 
+#ifdef EXL_LOAD_KIND_MODULE
+        static ALWAYS_INLINE void InstallAtSymbol(const char* symbol) {
+            _HOOK_STATIC_CALLBACK_ASSERT();
+
+            uintptr_t address = 0;
+            EXL_ASSERT(R_SUCCEEDED(nn::ro::LookupSymbol(&address, symbol)), "Symbol not found!");
+
+            hook::HookInline(address, Derived::Callback);
+        }
+#endif
     };
 }

--- a/source/lib/hook/replace.hpp
+++ b/source/lib/hook/replace.hpp
@@ -4,6 +4,10 @@
 #include "util/func_ptrs.hpp"
 #include "util/type_traits.hpp"
 
+#ifdef EXL_LOAD_KIND_MODULE
+#include "ro.h"
+#endif
+
 #define HOOK_DEFINE_REPLACE(name)                        \
 struct name : public ::exl::hook::impl::ReplaceHook<name>
 
@@ -36,5 +40,16 @@ namespace exl::hook::impl {
             
             hook::Hook(ptr, Derived::Callback);
         }
+
+#ifdef EXL_LOAD_KIND_MODULE
+        static ALWAYS_INLINE void InstallAtSymbol(const char* symbol) {
+            _HOOK_STATIC_CALLBACK_ASSERT();
+
+            uintptr_t address = 0;
+            EXL_ASSERT(R_SUCCEEDED(nn::ro::LookupSymbol(&address, symbol)), "Symbol not found!");
+
+            hook::Hook(address, Derived::Callback);
+        }
+#endif
     };
 }

--- a/source/lib/hook/trampoline.hpp
+++ b/source/lib/hook/trampoline.hpp
@@ -4,6 +4,10 @@
 #include "util/func_ptrs.hpp"
 #include <functional>
 
+#ifdef EXL_LOAD_KIND_MODULE
+#include "ro.h"
+#endif
+
 #define HOOK_DEFINE_TRAMPOLINE(name)                        \
 struct name : public ::exl::hook::impl::TrampolineHook<name>
 
@@ -46,6 +50,17 @@ namespace exl::hook::impl {
             
             OrigRef() = hook::Hook(ptr, Derived::Callback, true);
         }
+
+#ifdef EXL_LOAD_KIND_MODULE
+        static ALWAYS_INLINE void InstallAtSymbol(const char* symbol) {
+            _HOOK_STATIC_CALLBACK_ASSERT();
+
+            uintptr_t address = 0;
+            EXL_ASSERT(R_SUCCEEDED(nn::ro::LookupSymbol(&address, symbol)), "Symbol not found!");
+
+            OrigRef() = hook::Hook(address, Derived::Callback, true);
+        }
+#endif
     };
 
 }

--- a/source/lib/util/type_traits.hpp
+++ b/source/lib/util/type_traits.hpp
@@ -2,9 +2,7 @@
 
 namespace exl::util {
     template<typename T>
-    struct FuncPtrTraits {
-        static_assert(false, "Unsupported type.");
-    };
+    struct FuncPtrTraits;
 
     /* Regular C function pointer. */
     template<typename R, typename... Args>

--- a/source/nn.hpp
+++ b/source/nn.hpp
@@ -8,3 +8,4 @@
 #include "nn/fs.hpp"
 #include "nn/os.hpp"
 #include "nn/time.hpp"
+#include "nn/ro.h"

--- a/source/nn/ro.h
+++ b/source/nn/ro.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
+namespace nn::ro {
+::Result LookupSymbol(uintptr_t *out, const char *name);
+}


### PR DESCRIPTION
The obligatory usage:
```c++
MyHook::InstallAtSymbol("_ZN10StageScene7exePlayEv");
```
A `static_assert(false)` in `type_traits.hpp` caused the compilation to fail, since the compiler tried to substitute uintptr_t in `FuncPtrTraits` to test the application of a templated function.