### PR TITLE
Fix InlineFloatCtx (hopefully) and add support for newest rtld version (fix crash on boot + module name printing)

### DIFF
--- a/misc/link.ld
+++ b/misc/link.ld
@@ -32,7 +32,11 @@ SECTIONS
   . = ALIGN(0x1000);
 
   /* App name */
-  .module_name : { KEEP (*(.nx-module-name)) } :rodata
+  .module_name : { 
+    HIDDEN(__module_name_start__ = .);
+    KEEP (*(.nx-module-name))
+    HIDDEN(__module_name_end__ = .);
+  } :rodata
 
   /* Make sure everything is aligned */
   . = ALIGN(8);
@@ -74,7 +78,11 @@ SECTIONS
   .eh_frame : { KEEP (*(.eh_frame)) } :rodata
 
   /* Misc .rodata stuffs (build-id, etc.) */
-  .note.gnu.build-id : { *(.note.gnu.build-id) } :rodata
+  .note.gnu.build-id : {
+    HIDDEN(__note_gnu_build_id_start__ = .);
+    *(.note.gnu.build-id)
+    HIDDEN(__note_gnu_build_id_end__ = .);
+  } :rodata
 
   /* Read-write sections */
   . = ALIGN(0x1000);
@@ -83,6 +91,8 @@ SECTIONS
   .data : {
     *(.data .data.*)
   } :data
+  
+  HIDDEN(__relro_start__ = .);
 
   /* This section should be made read only after relocation but in practice we will not do that */
   .data.rela.ro : {
@@ -95,6 +105,8 @@ SECTIONS
     *(.data.rel.ro.local*)
     *(.data.rel.ro .data.rel.ro.*)
   } :data
+
+  HIDDEN(__full_relro_end__ = .);
 
   /* All GOT sections */
   __got_start__ = .;

--- a/source/lib/hook/nx64/inline_impl.hpp
+++ b/source/lib/hook/nx64/inline_impl.hpp
@@ -96,7 +96,7 @@ namespace exl::hook::nx64 {
         };
     };
 
-    struct InlineFloatCtx : public InlineCtx {
+    struct InlineFloatCtx {
         /* Ensure the data is aligned for efficient access. */
         union ALIGNED(sizeof(FloatRegister)) {
             /* Accessors to simplify access to registers. */
@@ -106,6 +106,12 @@ namespace exl::hook::nx64 {
             impl::Float64RegisterAccessor D;
             impl::Float32RegisterAccessor S;
             FloatRegisters m_Fr;
+        };
+        union {
+            /* Accessors are union'd with the gprs so that they can be accessed directly. */
+            impl::Gp64RegisterAccessor X;
+            impl::Gp32RegisterAccessor W;
+            GpRegisters m_Gpr;
         };
 
         /* 

--- a/source/lib/init/crt0.s
+++ b/source/lib/init/crt0.s
@@ -18,7 +18,7 @@
 __module_start:
     // newer rtld versions check the first four bytes to determine the version
     // 0, `b #0x8` (arm), or `b #0xc` (aarch64) are treated as the older version anything else is treated as the new version
-    // older versions of rtld appear to not care about what comes after the runtime module offset
+    // older versions of rtld appear to not care about what comes after the module header offset
     b entrypoint
     .word __nx_mod0 - __module_start
     .word __unused_garbage - __module_start

--- a/source/lib/init/crt0.s
+++ b/source/lib/init/crt0.s
@@ -21,7 +21,7 @@ __module_start:
     // older versions of rtld appear to not care about what comes after the module header offset
     b entrypoint
     .word __nx_mod0 - __module_start
-    .word __unused_garbage - __module_start
+    .word __sdk_version - __module_start
 
     .align 4
     .ascii "~~exlaunch uwu~~"
@@ -99,8 +99,8 @@ __nx_mod0:
     .word  exl_nx_module_runtime    - __nx_mod0
     // newer versions have a longer module header, but the other fields aren't directly used so we can ignore them
 
-// a pointer to this is passed to nn::ro::ProtectRelro on later versions but it's unused
-__unused_garbage:
-    .word   20
-    .word   5
-    .word   6
+// sdk version (unused so it doesn't actually matter what's here)
+__sdk_version:
+    .word   69
+    .word   420
+    .word   69

--- a/source/lib/init/crt0.s
+++ b/source/lib/init/crt0.s
@@ -16,8 +16,12 @@
 
 .global __module_start
 __module_start:
+    // newer rtld versions check the first four bytes to determine the version
+    // 0, `b #0x8` (arm), or `b #0xc` (aarch64) are treated as the older version anything else is treated as the new version
+    // older versions of rtld appear to not care about what comes after the runtime module offset
     b entrypoint
     .word __nx_mod0 - __module_start
+    .word __unused_garbage - __module_start
 
     .align 4
     .ascii "~~exlaunch uwu~~"
@@ -93,3 +97,10 @@ __nx_mod0:
     .word  __eh_frame_hdr_start__   - __nx_mod0
     .word  __eh_frame_hdr_end__     - __nx_mod0
     .word  exl_nx_module_runtime    - __nx_mod0
+    // newer versions have a longer module header, but the other fields aren't directly used so we can ignore them
+
+// a pointer to this is passed to nn::ro::ProtectRelro on later versions but it's unused
+__unused_garbage:
+    .word   20
+    .word   5
+    .word   6

--- a/source/lib/init/crt0.s
+++ b/source/lib/init/crt0.s
@@ -17,7 +17,7 @@
 .global __module_start
 __module_start:
     // newer rtld versions check the first four bytes to determine the version
-    // 0, `b #0x8` (arm), or `b #0xc` (aarch64) are treated as the older version anything else is treated as the new version
+    // 0, `b #0x8` (arm), or `b #0x8` (aarch64) are treated as the older version anything else is treated as the new version
     // older versions of rtld appear to not care about what comes after the module header offset
     b entrypoint
     .word __nx_mod0 - __module_start
@@ -91,16 +91,22 @@ bss_loop:
 .align 2
 __nx_mod0:
     .ascii "MOD0"
-    .word  __dynamic_start__        - __nx_mod0
-    .word  __bss_start__            - __nx_mod0
-    .word  __bss_end__              - __nx_mod0
-    .word  __eh_frame_hdr_start__   - __nx_mod0
-    .word  __eh_frame_hdr_end__     - __nx_mod0
-    .word  exl_nx_module_runtime    - __nx_mod0
-    // newer versions have a longer module header, but the other fields aren't directly used so we can ignore them
+    .word  __dynamic_start__            - __nx_mod0
+    .word  __bss_start__                - __nx_mod0
+    .word  __bss_end__                  - __nx_mod0
+    .word  __eh_frame_hdr_start__       - __nx_mod0
+    .word  __eh_frame_hdr_end__         - __nx_mod0
+    .word  exl_nx_module_runtime        - __nx_mod0
+    // these are only present in newer header versions, but newer sdk versions may check these so we should include them
+    .word   __relro_start__             - __nx_mod0
+    .word   __full_relro_end__          - __nx_mod0
+    .word   __module_name_start__       - __nx_mod0
+    .word   __module_name_end__         - __nx_mod0
+    .word   __note_gnu_build_id_start__ - __nx_mod0
+    .word   __note_gnu_build_id_end__   - __nx_mod0
 
-// sdk version (unused so it doesn't actually matter what's here)
+// this will only be checked if something throws an exception
 __sdk_version:
-    .word   69
-    .word   420
-    .word   69
+    .word   20
+    .word   5
+    .word   6

--- a/source/lib/util/sys/module_info.hpp
+++ b/source/lib/util/sys/module_info.hpp
@@ -17,16 +17,28 @@ namespace exl::util {
         const Mod0* m_Mod;
 
         std::string_view GetModulePath() const {
-            struct {
-                std::uint32_t m_Unk;
-                std::uint32_t m_Length;
-                char m_Data[s_ModulePathLengthMax];
-            }* module;
-            auto ptr = reinterpret_cast<decltype(module)>(m_Rodata.m_Start);
-            if(ptr->m_Length == 0)
-                return "";
-
-            return { ptr->m_Data, ptr->m_Length };
+            const auto version = *reinterpret_cast<std::uint32_t*>(m_Rodata.m_Start);
+            if(version == 0) {
+                struct {
+                    std::uint32_t m_Version;
+                    std::uint32_t m_Length;
+                    char m_Data[s_ModulePathLengthMax];
+                }* module;
+                auto ptr = reinterpret_cast<decltype(module)>(m_Rodata.m_Start);
+                return { ptr->m_Data, ptr->m_Length };
+            } else if(version == 1) {
+                struct {
+                    std::uint32_t m_Version;
+                    std::uint32_t m_Mod0Offset;
+                    std::uint32_t m_UnkOffset; // ptr passed to nn::ro::ProtectRelro but is unused
+                    std::uint32_t m_Unk; // 0
+                    std::uint32_t m_Length;
+                    char m_Data[s_ModulePathLengthMax];
+                }* module;
+                auto ptr = reinterpret_cast<decltype(module)>(m_Rodata.m_Start);
+                return { ptr->m_Data, ptr->m_Length };
+            }
+            return "";
         }
 
         std::string_view GetModuleName() const {


### PR DESCRIPTION
InlineFloatCtx was adjusted so that the GPRs are now placed after the floating-point registers to match how they are backed up (closes #28).

`crt0.s` was adjusted to conform to a layout compatible with what newer versions of rtld expect (all while preserving the ever important `~~exlaunch uwu~~`).

`module_info.hpp` was updated to support proper parsing of module names for modules which use the new layout.

Here are the updated rtld structures for reference:
```cpp
// at the beginning of .text for each module
struct TextSectionHeader {
    u32 entry_instr;
    s32 header_offset;
    s32 sdk_version_offset;
    
    bool IsNewVersion() const {
        return entry_instr != 0xea000000 /* b #0x8 (arm) */ && entry_instr != 0 && entry_instr != 0x14000002 /* b #0x8 (aarch64) */;
    }
};

struct SdkVersion {
    u32 major;
    u32 minor;
    u32 patch;
};

struct ModuleHeader {
    u32 magic; // MOD0
    // offsets relative to the start of the header
    s32 dynamic_offset;
    s32 bss_start_offset;
    s32 bss_end_offset;
    s32 eh_framehdr_start_offset;
    s32 eh_framehdr_end_offset;
    s32 runtime_module_offset;
    // only exist in the new version
    s32 data_offset;
    s32 initialized_offset; // value that's set once module runtime initialization is finished
    s32 module_name_start_offset; // offset to the start of the module name struct, not the name itself
    s32 module_name_end_offset;
    s32 gnu_build_id_start_offset;
    s32 gnu_build_id_end_offset;
};

// found at the start of .rodata for each module
struct ModuleName {
    u32 version;
    union {
        struct {
            u32 name_length;
            char name[];
        } version0;
        struct {
            u32 module_header_offset;
            u32 version_offset;
            u32 unk; // 0, I think this is just the version 0 struct again (module name offset points to here)
            u32 name_length;
            char name[];
        } version1;
    };
};

// rtld module object
struct RoModule {
    RoModule* m_pNext;
    RoModule* m_pPrev;
    union {
        Elf64_Rela* m_RelaPlt;
        Elf64_Rel* m_RelPlt;
    };
    union {
        Elf64_Rela* m_Rela;
        Elf64_Rel* m_Rel;
    };
    u64 _20; // if non-zero, ProtectRelro returns early
    void* m_Base;
    struct {
        Elf64_Dyn* dyn;
        Elf64_Xword pltRelocSize;
        void (*dt_init)(void);
        void (*dt_fini)(void);
        union {
            Elf64_Word* bucket;     // normal hash
            Elf64_Xword* bloom;     // GNU hash
        };
        union {
            Elf64_Word* chain;      // normal hash
            Elf64_Word bloomSize;   // GNU hash
        };
        char* strTable;
        Elf64_Sym* symTable;
        Elf64_Xword strTableSize;
        void* pltGot;
        Elf64_Xword relaSize;
        Elf64_Xword relSize;
        Elf64_Xword relEntryCount;
        Elf64_Xword relaEntryCount;
        union {
            Elf64_Xword nchain;     // normal hash
            Elf64_Xword bloomShift; // GNU hash
        };
        union {
            Elf64_Xword nbucket;    // normal hash
            Elf64_Word* hashTable;  // GNU hash
        };
        Elf64_Xword sharedObjectNameOffset;
        void* moduleEnd;
        u8 _90; // 0x14
        char _91[2];
        u8 flags;
        void* defaultPltGot;
    } m_ArchData;
    
    enum Flags {
        Flags_Rela          = 1 << 1; // DT_RELA as opposed to DT_REL
        Flags_BindNow       = 1 << 2; // DT_BIND_NOW
        Flags_HasNonFunc    = 1 << 3; // has a symbol that isn't STT_FUNC
        Flags_GnuHash       = 1 << 4; // DT_GNU_HASH
    };
};
```